### PR TITLE
Use unofficial LangSegment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,7 @@ pypinyin==0.53.0
 onnxruntime
 Unidecode==1.3.8
 phonemizer==3.3.0
-LangSegment==0.3.5
 inflect==7.5.0
+
+# Use unofficial LangSegment from github
+-e git+https://github.com:xkmato/LangSegment.git#egg=LangSegment


### PR DESCRIPTION
It seems like the official LangSegment has been pulled from all official release channels. This means that it is impossible to install version 0.3+ which is needed to run this repo. This PR uses an unofficial version of LangSegment version 0.3.2 which works for this segment.