### PR TITLE
Fix Windows repo id argument

### DIFF
--- a/scripts/infer_prompt_ref.bat
+++ b/scripts/infer_prompt_ref.bat
@@ -1,2 +1,2 @@
-python %~dp0..\infer\infer.py --lrc-path infer/example/eg_en.lrc --ref-prompt "classical genres, hopeful mood, piano." --audio-length 95 --repo_id ASLP-lab/DiffRhythm-1_2 --output-dir infer/example/output_en --chunked
+python %~dp0..\infer\infer.py --lrc-path infer/example/eg_en.lrc --ref-prompt "classical genres, hopeful mood, piano." --audio-length 95 --repo-id ASLP-lab/DiffRhythm-1_2 --output-dir infer/example/output_en --chunked
 pause

--- a/scripts/infer_wav_ref.bat
+++ b/scripts/infer_wav_ref.bat
@@ -1,2 +1,2 @@
-python %~dp0..\infer\infer.py --lrc-path infer/example/eg_en.lrc --ref-audio-path infer/example/eg_cn.wav --audio-length 95 --repo_id ASLP-lab/DiffRhythm-1_2 --output-dir infer/example/output_en --chunked
+python %~dp0..\infer\infer.py --lrc-path infer/example/eg_en.lrc --ref-audio-path infer/example/eg_cn.wav --audio-length 95 --repo-id ASLP-lab/DiffRhythm-1_2 --output-dir infer/example/output_en --chunked
 pause


### PR DESCRIPTION
Fix the error "infer.py: error: unrecognized arguments: --repo_id ASLP-lab/DiffRhythm-1_2" when call scripts\infer_prompt_ref.bat 
